### PR TITLE
STVar: optimized storage for STObject (RIPD-825):

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -2324,16 +2324,20 @@
     <ClInclude Include="..\..\src\ripple\legacy\0.27\book\BookTip.h">
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\legacy\0.27\book\impl\BookTip.cpp">
-      <ExcludedFromBuild>True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\legacy\0.27\book\impl\OfferStream.cpp">
-      <ExcludedFromBuild>True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\legacy\0.27\book\impl\Quality.cpp">
-      <ExcludedFromBuild>True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\legacy\0.27\book\impl\Taker.cpp">
-      <ExcludedFromBuild>True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\legacy\0.27\book\Offer.h">
     </ClInclude>
@@ -2346,12 +2350,14 @@
     <ClInclude Include="..\..\src\ripple\legacy\0.27\book\Types.h">
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\legacy\0.27\CreateOffer.cpp">
-      <ExcludedFromBuild>True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\legacy\0.27\CreateOffer.h">
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\legacy\0.27\Emulate027.cpp">
-      <ExcludedFromBuild>True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\legacy\0.27\Emulate027.h">
     </ClInclude>
@@ -2799,6 +2805,8 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClInclude Include="..\..\src\ripple\protocol\impl\STVar.h">
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\protocol\impl\STVector256.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -3546,6 +3546,9 @@
     <ClCompile Include="..\..\src\ripple\protocol\impl\STValidation.cpp">
       <Filter>ripple\protocol\impl</Filter>
     </ClCompile>
+    <ClInclude Include="..\..\src\ripple\protocol\impl\STVar.h">
+      <Filter>ripple\protocol\impl</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\protocol\impl\STVector256.cpp">
       <Filter>ripple\protocol\impl</Filter>
     </ClCompile>

--- a/src/ripple/app/ledger/LedgerEntrySet.cpp
+++ b/src/ripple/app/ledger/LedgerEntrySet.cpp
@@ -508,25 +508,25 @@ void LedgerEntrySet::calcRawMeta (Serializer& s, TER result, std::uint32_t index
             threadOwners (origNode, mLedger, newMod); // thread transaction to owners
 
             STObject prevs (sfPreviousFields);
-            for (auto const& obj : *origNode)
+            for (auto const& obj : origNode->items())
             {
                 // go through the original node for modified fields saved on modification
                 if (obj.getFName ().shouldMeta (SField::sMD_ChangeOrig) && !curNode->hasMatchingEntry (obj))
                     prevs.addObject (obj);
             }
 
-            if (!prevs.empty ())
+            if (!prevs.items().empty ())
                 mSet.getAffectedNode (it.first).addObject (prevs);
 
             STObject finals (sfFinalFields);
-            for (auto const& obj : *curNode)
+            for (auto const& obj : curNode->items())
             {
                 // go through the final node for final fields
                 if (obj.getFName ().shouldMeta (SField::sMD_Always | SField::sMD_DeleteFinal))
                     finals.addObject (obj);
             }
 
-            if (!finals.empty ())
+            if (!finals.items().empty ())
                 mSet.getAffectedNode (it.first).addObject (finals);
         }
         else if (type == &sfModifiedNode)
@@ -537,25 +537,25 @@ void LedgerEntrySet::calcRawMeta (Serializer& s, TER result, std::uint32_t index
                 threadTx (curNode, mLedger, newMod);
 
             STObject prevs (sfPreviousFields);
-            for (auto const& obj : *origNode)
+            for (auto const& obj : origNode->items())
             {
                 // search the original node for values saved on modify
                 if (obj.getFName ().shouldMeta (SField::sMD_ChangeOrig) && !curNode->hasMatchingEntry (obj))
                     prevs.addObject (obj);
             }
 
-            if (!prevs.empty ())
+            if (!prevs.items().empty ())
                 mSet.getAffectedNode (it.first).addObject (prevs);
 
             STObject finals (sfFinalFields);
-            for (auto const& obj : *curNode)
+            for (auto const& obj : curNode->items())
             {
                 // search the final node for values saved always
                 if (obj.getFName ().shouldMeta (SField::sMD_Always | SField::sMD_ChangeNew))
                     finals.addObject (obj);
             }
 
-            if (!finals.empty ())
+            if (!finals.items().empty ())
                 mSet.getAffectedNode (it.first).addObject (finals);
         }
         else if (type == &sfCreatedNode) // if created, thread to owner(s)
@@ -567,14 +567,14 @@ void LedgerEntrySet::calcRawMeta (Serializer& s, TER result, std::uint32_t index
                 threadTx (curNode, mLedger, newMod);
 
             STObject news (sfNewFields);
-            for (auto const& obj : *curNode)
+            for (auto const& obj : curNode->items())
             {
                 // save non-default values
                 if (!obj.isDefault () && obj.getFName ().shouldMeta (SField::sMD_Create | SField::sMD_Always))
                     news.addObject (obj);
             }
 
-            if (!news.empty ())
+            if (!news.items().empty ())
                 mSet.getAffectedNode (it.first).addObject (news);
         }
         else assert (false);

--- a/src/ripple/app/tx/TransactionMeta.cpp
+++ b/src/ripple/app/tx/TransactionMeta.cpp
@@ -109,7 +109,7 @@ std::vector<RippleAddress> TransactionMetaSet::getAffectedAccounts ()
 
             if (inner)
             {
-                for (auto const& field : inner->peekData ())
+                for (auto const& field : inner->items())
                 {
                     const STAccount* sa = dynamic_cast<const STAccount*> (&field);
 

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -44,6 +44,27 @@ public:
     {
         ;
     }
+
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
+
     static std::unique_ptr<STBase> deserialize (SerialIter& sit, SField::ref name)
     {
         return std::unique_ptr<STBase> (construct (sit, name));

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -45,6 +45,12 @@ public:
         ;
     }
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -38,7 +38,7 @@ namespace ripple {
 // Wire form:
 // High 8 bits are (offset+142), legal range is, 80 to 22 inclusive
 // Low 56 bits are value, legal range is 10^15 to (10^16 - 1) inclusive
-class STAmount final
+class STAmount
     : public STBase
 {
 public:
@@ -103,6 +103,26 @@ public:
     STAmount (Issue const& issue, std::int64_t mantissa, int exponent = 0);
 
     STAmount (Issue const& issue, int mantissa, int exponent = 0);
+
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
 
     //--------------------------------------------------------------------------
 

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -104,6 +104,12 @@ public:
 
     STAmount (Issue const& issue, int mantissa, int exponent = 0);
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STArray.h
+++ b/src/ripple/protocol/STArray.h
@@ -76,6 +76,12 @@ public:
     std::unique_ptr<STBase>
     deserialize (SerialIter & sit, SField::ref name);
   
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STArray.h
+++ b/src/ripple/protocol/STArray.h
@@ -75,6 +75,26 @@ public:
     static
     std::unique_ptr<STBase>
     deserialize (SerialIter & sit, SField::ref name);
+  
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
 
     const vector& getValue () const
     {

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -26,7 +26,8 @@
 #include <beast/cxx14/memory.h> // <memory>
 #include <string>
 #include <typeinfo>
-
+#include <utility>
+#include <beast/cxx14/type_traits.h> // <type_traits>
 namespace ripple {
 
 // VFALCO TODO fix this restriction on copy assignment.
@@ -69,6 +70,28 @@ public:
 
     bool operator== (const STBase& t) const;
     bool operator!= (const STBase& t) const;
+
+    virtual
+    STBase*
+    copy (std::size_t n, void* buf) const
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    virtual
+    STBase*
+    move (std::size_t n, void* buf)
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
 
     template <class D>
     D&

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -72,6 +72,13 @@ public:
     bool operator!= (const STBase& t) const;
 
     virtual
+    std::size_t
+    size_of() const
+    {
+        return sizeof(*this);
+    }
+
+    virtual
     STBase*
     copy (std::size_t n, void* buf) const
     {

--- a/src/ripple/protocol/STBitString.h
+++ b/src/ripple/protocol/STBitString.h
@@ -64,6 +64,26 @@ public:
         return std::make_unique<STBitString> (name, sit.getBitString<Bits> ());
     }
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
+
     SerializedTypeID
     getSType () const override;
 

--- a/src/ripple/protocol/STBitString.h
+++ b/src/ripple/protocol/STBitString.h
@@ -64,6 +64,12 @@ public:
         return std::make_unique<STBitString> (name, sit.getBitString<Bits> ());
     }
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STBlob.h
+++ b/src/ripple/protocol/STBlob.h
@@ -79,6 +79,26 @@ public:
         return std::make_unique<STBlob> (name, sit.getVLBuffer ());
     }
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
+
     std::size_t
     size() const
     {

--- a/src/ripple/protocol/STBlob.h
+++ b/src/ripple/protocol/STBlob.h
@@ -79,6 +79,12 @@ public:
         return std::make_unique<STBlob> (name, sit.getVLBuffer ());
     }
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STInteger.h
+++ b/src/ripple/protocol/STInteger.h
@@ -44,6 +44,26 @@ public:
     std::unique_ptr<STBase>
     deserialize (SerialIter& sit, SField::ref name);
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
+
     SerializedTypeID
     getSType () const override;
 

--- a/src/ripple/protocol/STInteger.h
+++ b/src/ripple/protocol/STInteger.h
@@ -44,6 +44,12 @@ public:
     std::unique_ptr<STBase>
     deserialize (SerialIter& sit, SField::ref name);
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STLedgerEntry.h
+++ b/src/ripple/protocol/STLedgerEntry.h
@@ -41,6 +41,12 @@ public:
     STLedgerEntry (LedgerEntryType type, uint256 const& index);
     STLedgerEntry (const STObject & object, uint256 const& index);
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STLedgerEntry.h
+++ b/src/ripple/protocol/STLedgerEntry.h
@@ -41,6 +41,26 @@ public:
     STLedgerEntry (LedgerEntryType type, uint256 const& index);
     STLedgerEntry (const STObject & object, uint256 const& index);
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
+
     SerializedTypeID getSType () const override
     {
         return STI_LEDGERENTRY;

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -82,6 +82,12 @@ public:
             v_.emplace_back(b);
     }
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -43,6 +43,11 @@ class STObject
     , public CountedObject <STObject>
 {
 private:
+    enum
+    {
+        reserveSize = 20
+    };
+
     struct Log
     {
         std::mutex mutex_;
@@ -77,38 +82,17 @@ public:
 
     static char const* getCountedObjectName () { return "STObject"; }
 
-    STObject () : mType (nullptr)
-    {
-        ;
-    }
+    STObject();
 
-    explicit STObject (SField::ref name)
-        : STBase (name), mType (nullptr)
-    {
-        ;
-    }
+    explicit STObject (SField::ref name);
 
-    STObject (const SOTemplate & type, SField::ref name)
-        : STBase (name)
-    {
-        set (type);
-    }
+    STObject (const SOTemplate & type, SField::ref name);
 
-    STObject (
-        const SOTemplate & type, SerialIter & sit, SField::ref name)
-        : STBase (name)
-    {
-        set (sit);
-        setType (type);
-    }
+    STObject (const SOTemplate & type,
+        SerialIter & sit, SField::ref name);
 
-    STObject (SField::ref name, boost::ptr_vector<STBase>& data)
-        : STBase (name), mType (nullptr)
-    {
-        v_.reserve(data.size());
-        for (auto const& b : data)
-            v_.emplace_back(b);
-    }
+    STObject (SField::ref name,
+        boost::ptr_vector<STBase>& data);
 
     virtual ~STObject();
 

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -241,6 +241,12 @@ public:
     std::unique_ptr<STBase>
     deserialize (SerialIter& sit, SField::ref name);
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -241,6 +241,26 @@ public:
     std::unique_ptr<STBase>
     deserialize (SerialIter& sit, SField::ref name);
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
+
     std::unique_ptr<STBase>
     duplicate () const override
     {

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -56,6 +56,12 @@ public:
     // Only called from ripple::RPC::transactionSign - can we eliminate this?
     explicit STTx (STObject const& object);
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -56,6 +56,26 @@ public:
     // Only called from ripple::RPC::transactionSign - can we eliminate this?
     explicit STTx (STObject const& object);
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
+
     // STObject functions
     SerializedTypeID getSType () const override
     {

--- a/src/ripple/protocol/STValidation.h
+++ b/src/ripple/protocol/STValidation.h
@@ -52,6 +52,12 @@ public:
     STValidation (uint256 const& ledgerHash, std::uint32_t signTime,
                           const RippleAddress & raPub, bool isFull);
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STValidation.h
+++ b/src/ripple/protocol/STValidation.h
@@ -52,6 +52,26 @@ public:
     STValidation (uint256 const& ledgerHash, std::uint32_t signTime,
                           const RippleAddress & raPub, bool isFull);
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
+
     uint256         getLedgerHash ()     const;
     std::uint32_t   getSignTime ()       const;
     std::uint32_t   getFlags ()          const;

--- a/src/ripple/protocol/STVector256.h
+++ b/src/ripple/protocol/STVector256.h
@@ -41,6 +41,12 @@ public:
         : mValue (vector)
     { }
 
+    std::size_t
+    size_of() const override
+    {
+        return sizeof(*this);
+    }
+
     STBase*
     copy (std::size_t n, void* buf) const override
     {

--- a/src/ripple/protocol/STVector256.h
+++ b/src/ripple/protocol/STVector256.h
@@ -41,6 +41,26 @@ public:
         : mValue (vector)
     { }
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(*this);
+        return new(buf) std::decay_t<
+            decltype(*this)>(*this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        if (sizeof(*this) > n)
+            return new std::decay_t<
+                decltype(*this)>(std::move(*this));
+        return new(buf) std::decay_t<
+            decltype(*this)>(std::move(*this));
+    }
+
     SerializedTypeID
     getSType () const override
     {

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -40,6 +40,46 @@ STObject::~STObject()
 #endif
 }
 
+STObject::STObject()
+    : mType (nullptr)
+{
+    v_.reserve(reserveSize);
+}
+
+STObject::STObject (SField::ref name)
+    : STBase (name)
+    , mType (nullptr)
+{
+    v_.reserve(reserveSize);
+}
+
+STObject::STObject (SOTemplate const& type,
+        SField::ref name)
+    : STBase (name)
+{
+    v_.reserve(reserveSize);
+    set (type);
+}
+
+STObject::STObject (SOTemplate const& type,
+        SerialIter & sit, SField::ref name)
+    : STBase (name)
+{
+    v_.reserve(reserveSize);
+    set (sit);
+    setType (type);
+}
+
+STObject::STObject (SField::ref name,
+        boost::ptr_vector<STBase>& data)
+    : STBase (name)
+    , mType (nullptr)
+{
+    v_.reserve(data.size());
+    for (auto const& b : data)
+        v_.emplace_back(b);
+}
+
 std::unique_ptr<STBase>
 STObject::makeDefaultObject (SerializedTypeID id, SField::ref name)
 {

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -31,6 +31,15 @@
 
 namespace ripple {
 
+STObject::~STObject()
+{
+#if 0
+    // Turn this on to get a histogram on exit
+    static beast::static_initializer<Log> log;
+    (*log)(v_.size());
+#endif
+}
+
 std::unique_ptr<STBase>
 STObject::makeDefaultObject (SerializedTypeID id, SField::ref name)
 {

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -125,7 +125,7 @@ STTx::getMentionedAccounts () const
 {
     std::vector<RippleAddress> accounts;
 
-    for (auto const& it : peekData ())
+    for (auto const& it : items())
     {
         if (auto sa = dynamic_cast<STAccount const*> (&it))
         {
@@ -314,7 +314,7 @@ isMemoOkay (STObject const& st, std::string& reason)
             return false;
         }
 
-        for (auto const& memoElement : *memoObj)
+        for (auto const& memoElement : memoObj->items())
         {
             auto const& name = memoElement.getFName();
 

--- a/src/ripple/protocol/impl/STVar.h
+++ b/src/ripple/protocol/impl/STVar.h
@@ -39,7 +39,7 @@ namespace detail {
 class STVar
 {
 private:
-    std::aligned_storage<64>::type d_;
+    std::aligned_storage<72>::type d_;
     STBase* p_ = nullptr;
 
     struct Log
@@ -168,11 +168,14 @@ private:
     void
     destroy()
     {
+    #if 0
+        // Turn this on to get a histogram on exit
         if (p_ != nullptr)
         {
             static beast::static_initializer<Log> log;
             (*log)(p_->size_of());
         }
+    #endif
 
         if (on_heap())
             delete p_;

--- a/src/ripple/protocol/impl/STVar.h
+++ b/src/ripple/protocol/impl/STVar.h
@@ -26,10 +26,10 @@
 #include <utility>
 #include <typeinfo>
 
-#include <mutex>
-#include <unordered_map>
 #include <beast/streams/debug_ostream.h>
 #include <beast/utility/static_initializer.h>
+#include <mutex>
+#include <unordered_map>
 
 namespace ripple {
 namespace detail {


### PR DESCRIPTION
This introduces the STVar container, capable of holding any STBase-derived class and implementing a "small string" optimization. STObject is changed to store std::vector<STVar> instead of boost::ptr_vector<STBase>. This eliminates a significant number of needless dynamic memory allocations and deallocations during transaction processing when ledger entries are deserialized. It comes at the expense of larger overall storage requirements for STObject.
